### PR TITLE
prevent directory traversal

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,15 @@ Allows viewing of log files from the ZNC webadmin
 
 ## Usage
 
-Place `weblog.py` in your ZNC modules folder. Place the `tmpl` folder in a `weblog` subdirectory in your modules folder.
+Place `weblog.py` in your ZNC modules folder. Place the `tmpl` folder in a `weblog` subdirectory in your modules folder. E.g:
+
+```
+znc@znc:~/.znc/modules$ tree
+.
+|-- weblog
+|   `-- tmpl
+|       [...]
+`-- weblog.py
+
+2 directories, 6 files
+```

--- a/weblog.py
+++ b/weblog.py
@@ -2,7 +2,7 @@ import znc
 import os
 
 def is_safe_path(basedir, path):
-    return os.path.realpath(path).startswith(basedir)
+    return os.path.abspath(path).startswith(basedir)
 
 class weblog(znc.Module):
     module_types = [znc.CModInfo.GlobalModule]

--- a/weblog.py
+++ b/weblog.py
@@ -1,6 +1,8 @@
 import znc
-#from os import listdir, scope
 import os
+
+def is_safe_path(basedir, path):
+    return os.path.realpath(path).startswith(basedir)
 
 class weblog(znc.Module):
     module_types = [znc.CModInfo.GlobalModule]
@@ -75,6 +77,16 @@ class weblog(znc.Module):
 
     def viewlog(self, tmpl, dir, sock, page):
         base = self.getbase(sock)
+
+        if not is_safe_path(base, base + dir):
+            if page == "raw":
+                row = tmpl.AddRow("LogLoop")
+                row['log'] = "Error: invalid directory provided."
+                return
+            row = tmpl.AddRow("ErrorLoop")
+            row["error"] = "Invalid directory provided."
+            return
+
         path = base + dir
         row = tmpl.AddRow("LogLoop")
         with open(path, 'r', encoding='utf8') as log:


### PR DESCRIPTION
This is a fix for issue #1, as well as an example for the needed layout for the modules folder since the wording was a bit confusing.