### PR TITLE
Text appearence fix for dark themes

### DIFF
--- a/tmpl/log.tmpl
+++ b/tmpl/log.tmpl
@@ -8,7 +8,8 @@
 
 <style type="text/css">
 pre {
-  background: white;
+  background: WhiteSmoke;
+  color: black;
   white-space: pre-wrap;
   white-space: -moz-pre-wrap;
   white-space: -pre-wrap;


### PR DESCRIPTION
Users will no longer need to blindly select the text to read it.

On some browsers the logs showed only a white box with white text inside and the user had to select the text to read it.
This change imposes the black color to the text and changes the white background to a  eye friendly and standard color, to avoid stressing the eyes when logs are very long.